### PR TITLE
[fix] 실시간 아카이브 좋아요 링크 변경

### DIFF
--- a/kilometer-backend-api/src/main/java/com/kilometer/backend/controller/dto/module/realtimearchive/HeartDto.java
+++ b/kilometer-backend-api/src/main/java/com/kilometer/backend/controller/dto/module/realtimearchive/HeartDto.java
@@ -17,7 +17,7 @@ public class HeartDto {
 
     static HeartDto from(RealTimeArchiveDto realTimeArchiveDto) {
         return HeartDto.builder()
-                .link(ApiUrlUtils.getPickItemUrl(realTimeArchiveDto.getItemId()))
+                .link(ApiUrlUtils.getLikeArchiveUrl(realTimeArchiveDto.getItemId()))
                 .heartClicked(realTimeArchiveDto.isLiked())
                 .build();
     }

--- a/kilometer-backend-api/src/test/java/com/kilometer/backend/controller/dto/module/realtimearchive/HeartDtoTest.java
+++ b/kilometer-backend-api/src/test/java/com/kilometer/backend/controller/dto/module/realtimearchive/HeartDtoTest.java
@@ -19,7 +19,7 @@ class HeartDtoTest {
 
         assertAll(
                 () -> assertThat(heartDto.isHeartClicked()).isEqualTo(IS_LIKED),
-                () -> assertThat(heartDto.getLink()).isEqualTo("/api/pick/1?status=")
+                () -> assertThat(heartDto.getLink()).isEqualTo("/api/archives/1/like?status=")
         );
     }
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요? 
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
실시간 아카이브 API의 heart.link 값을 아카이브 좋아요 값에서 전시글 좋아요 링크로 수정
 
## 스크린샷
as-is:
```
public class HeartDto {

    ...

    static HeartDto from(RealTimeArchiveDto realTimeArchiveDto) {
        return HeartDto.builder()
                .link(ApiUrlUtils.getPickItemUrl(realTimeArchiveDto.getItemId()))
                .heartClicked(realTimeArchiveDto.isLiked())
                .build();
    }

    ...
}
```
to-be:
```
public class HeartDto {

    ...

    static HeartDto from(RealTimeArchiveDto realTimeArchiveDto) {
        return HeartDto.builder()
                .link(ApiUrlUtils.getLikeArchiveUrl(realTimeArchiveDto.getItemId()))
                .heartClicked(realTimeArchiveDto.isLiked())
                .build();
    }

    ...
}
```
## 주의사항

Closes #265 