### PR TITLE
[fix] 실시간 아카이브 데이터 응답이 중복되는 문제 해결

### DIFF
--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
@@ -203,7 +203,8 @@ public class ArchiveRepositoryCustomImpl implements ArchiveRepositoryCustom {
                .distinct()
                .from(archive)
                .leftJoin(archiveImageEntity)
-               .on(archiveImageEntity.archiveEntity.eq(archive).and(archiveImageEntity.isNotNull()))
+               .on(archiveImageEntity.archiveEntity.eq(archive))
+               .where(archiveImageEntity.isNotNull())
                .orderBy(archiveEntity.updatedAt.desc())
                .limit(MAX_ARCHIVES)
                .fetch();

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
@@ -200,10 +200,10 @@ public class ArchiveRepositoryCustomImpl implements ArchiveRepositoryCustom {
     @Override
     public List<ArchiveEntity> findTopFourArchivesWithImageUrl() {
        return queryFactory.select(archiveEntity)
+               .distinct()
                .from(archive)
                .leftJoin(archiveImageEntity)
-               .on(archiveImageEntity.archiveEntity.eq(archive))
-               .where(archiveImageEntity.imageUrl.isNotNull())
+               .on(archiveImageEntity.archiveEntity.eq(archive).and(archiveImageEntity.isNotNull()))
                .orderBy(archiveEntity.updatedAt.desc())
                .limit(MAX_ARCHIVES)
                .fetch();


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [X] 🆗 로컬 스웨거에서 직접 실행해봤나요?
- [X] 💯 테스트는 잘 통과했나요? 
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
이미지가 존재하는 아카이브를 조회하는 쿼리 수정. 아카이브 이미지와 아카이브 테이블 관계가 N:1 인것을 간과해, 이미지 갯수 만큼 데이터가 조회되었습니다.

## 스크린샷
com.kilometer.domain.archive.archiverepositorycustomimpl
as-is:
```
@Override
    public List<ArchiveEntity> findTopFourArchivesWithImageUrl() {
       return queryFactory.select(archiveEntity)
               .from(archive)
               .leftJoin(archiveImageEntity)
               .on(archiveImageEntity.archiveEntity.eq(archive))
               .where(archiveImageEntity.isNotNull())
               .orderBy(archiveEntity.updatedAt.desc())
               .limit(MAX_ARCHIVES)
               .fetch();
    }
```
to-be:
```
@Override
    public List<ArchiveEntity> findTopFourArchivesWithImageUrl() {
       return queryFactory.select(archiveEntity)
               .distinct()
               .from(archive)
               .leftJoin(archiveImageEntity)
               .on(archiveImageEntity.archiveEntity.eq(archive))
               .where(archiveImageEntity.isNotNull())
               .orderBy(archiveEntity.updatedAt.desc())
               .limit(MAX_ARCHIVES)
               .fetch();
    }
```
## 주의사항

Closes #277 