### PR TITLE
bugfix - search archive 조회 부분 isDeleted 정책 미적용 수정

### DIFF
--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/item/ItemRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/item/ItemRepositoryCustomImpl.java
@@ -72,7 +72,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
             .leftJoin(pick)
             .on(pick.pickedItem.eq(itemEntity), eqUserId(queryRequest.getUserId()))
             .leftJoin(archive)
-            .on(archive.item.eq(itemEntity).and(archive.isVisibleAtItem.eq(true)))
+            .on(archive.item.eq(itemEntity).and(archive.isVisibleAtItem.isTrue()).and(archive.isDeleted.isFalse()))
             .where(
                 itemEntity.exposureType.eq(ExposureType.ON),
                 eqTitle(queryRequest.getQueryString()),
@@ -212,7 +212,8 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 itemEntity.feeType.eq(FeeType.FREE),
                 itemEntity.exposureType.eq(ExposureType.ON),
                 itemEntity.startDate.loe(now).and(itemEntity.endDate.gt(now)),
-                archive.isVisibleAtItem.isTrue()
+                archive.isVisibleAtItem.isTrue(),
+                archive.isDeleted.isFalse()
             )
             .groupBy(itemEntity.id)
             .orderBy(Expressions.numberTemplate(Long.class, "function('rand')").asc())


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [x] 🆗 로컬 스웨거에서 직접 실행해봤나요?
- [ ] 💯 테스트는 잘 통과했나요? 
- [x] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
itemRepositoryCustomImpl.java 부분에서 archive.isDeleted = 0 where 절 적용 안됨.
우선 해당 부분 조치 후 왜 그런지 원인 분석 예정

추측 
ArchiveEntity의 @Where(clause = "isDeleted=false") 부분 적용 되는 부분이랑 관계 있을 것으로 추정

## 스크린샷

## 주의사항

Closes #289 