### PR TITLE
[fix] 방문 장소 이름을 아카이브 사진 갯수 만큼 가져오는 문제

### DIFF
--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/homeModules/modules/realTimeArchive/RealTimeArchiveHandler.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/homeModules/modules/realTimeArchive/RealTimeArchiveHandler.java
@@ -57,6 +57,7 @@ public class RealTimeArchiveHandler implements ModuleHandler {
     private RealTimeArchiveDto combineVisitedPlaces(List<RealTimeArchiveDto> realTimeArchiveDtos) {
         String visitedPlaces = realTimeArchiveDtos.stream()
                 .map(RealTimeArchiveDto::getPlaceName)
+                .distinct()
                 .filter(Objects::nonNull)
                 .collect(Collectors.joining(", "));
 

--- a/kilometer-backend-domain/src/test/java/com/kilometer/domain/homeModules/modules/realTimeArchive/RealTimeArchiveHandlerTest.java
+++ b/kilometer-backend-domain/src/test/java/com/kilometer/domain/homeModules/modules/realTimeArchive/RealTimeArchiveHandlerTest.java
@@ -123,6 +123,30 @@ class RealTimeArchiveHandlerTest {
             assertThat(savedRealTimeArchiveResponse.getArchives().get(0).getPlaceName()).isEqualTo(PLACE_NAME + ", food");
         }
 
+        @DisplayName("같은 방문지 이름을 한번만 가지고 와야한다.")
+        @Test
+        void generateRealTimeArchiveWithDistinctPlaceName() {
+            User savedUser = saveUser();
+            ArchiveEntity savedArchive = saveArchive(savedUser);
+            saveUserVisitPlace(savedArchive);
+            UserVisitPlaceEntity userVisitPlace = UserVisitPlaceEntity.builder()
+                    .placeType(PlaceType.FOOD)
+                    .placeName("food")
+                    .address("address")
+                    .roadAddress("roadAddress")
+                    .archiveEntity(savedArchive)
+                    .build();
+            userVisitPlaceRepository.save(userVisitPlace);
+
+            saveArchiveImage(savedArchive);
+            saveArchiveImage(savedArchive);
+            saveArchiveLike(savedArchive, savedUser);
+            RealTimeArchiveResponse savedRealTimeArchiveResponse = (RealTimeArchiveResponse) saveRealTImeArchiveResponse(savedUser)
+                    .get();
+
+            assertThat(savedRealTimeArchiveResponse.getArchives().get(0).getPlaceName()).isEqualTo(PLACE_NAME + ", food");
+        }
+
         @DisplayName("아카이브 이미지가 존재하지 않으면 아카이브를 가져오지 않는다.")
         @Test
         void getArchiveThatDoesNotHaveImage() {


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [X] 🆗 로컬 스웨거에서 직접 실행해봤나요?
- [X] 💯 테스트는 잘 통과했나요? 
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 가져온 방문 장소 이름 중 중복된 이름을 거르는 코드 추가
## 스크린샷
RealTimeArchiveHandler.combineVisitedPlaces():
as-is:
```
private RealTimeArchiveDto combineVisitedPlaces(List<RealTimeArchiveDto> realTimeArchiveDtos) {
        String visitedPlaces = realTimeArchiveDtos.stream()
                .map(RealTimeArchiveDto::getPlaceName)
                .filter(Objects::nonNull)
                .collect(Collectors.joining(", "));
       ....
}
```
to-be:
```
private RealTimeArchiveDto combineVisitedPlaces(List<RealTimeArchiveDto> realTimeArchiveDtos) {
        String visitedPlaces = realTimeArchiveDtos.stream()
                .map(RealTimeArchiveDto::getPlaceName)
                .distinct()
                .filter(Objects::nonNull)
                .collect(Collectors.joining(", "));
       ....
}
```

## 주의사항

Closes #291 