### PR TITLE
[fix] 나만보기를 선택한 아카이브가 보이는 문제

### DIFF
--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustom.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustom.java
@@ -23,5 +23,5 @@ public interface ArchiveRepositoryCustom {
 
     List<RealTimeArchiveDto> findRealTimeArchive(long archiveId);
 
-    List<ArchiveEntity> findTopFourArchivesWithImageUrl();
+    List<ArchiveEntity> findTopFourVisibleAtItemArchivesWithImageUrl();
 }

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
@@ -198,7 +198,8 @@ public class ArchiveRepositoryCustomImpl implements ArchiveRepositoryCustom {
                .from(archive)
                .leftJoin(archiveImageEntity)
                .on(archiveImageEntity.archiveEntity.eq(archive))
-               .where(archiveImageEntity.isNotNull())
+               .where(archiveImageEntity.isNotNull(),
+                       archiveEntity.isVisibleAtItem.isTrue())
                .orderBy(archiveEntity.updatedAt.desc())
                .limit(MAX_ARCHIVES)
                .fetch();

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/archive/ArchiveRepositoryCustomImpl.java
@@ -192,7 +192,7 @@ public class ArchiveRepositoryCustomImpl implements ArchiveRepositoryCustom {
     }
 
     @Override
-    public List<ArchiveEntity> findTopFourArchivesWithImageUrl() {
+    public List<ArchiveEntity> findTopFourVisibleAtItemArchivesWithImageUrl() {
        return queryFactory.select(archiveEntity)
                .distinct()
                .from(archive)

--- a/kilometer-backend-domain/src/main/java/com/kilometer/domain/homeModules/modules/realTimeArchive/RealTimeArchiveHandler.java
+++ b/kilometer-backend-domain/src/main/java/com/kilometer/domain/homeModules/modules/realTimeArchive/RealTimeArchiveHandler.java
@@ -3,7 +3,6 @@ package com.kilometer.domain.homeModules.modules.realTimeArchive;
 import com.kilometer.domain.archive.ArchiveEntity;
 import com.kilometer.domain.archive.ArchiveRepository;
 import com.kilometer.domain.archive.dto.RealTimeArchiveDto;
-import com.kilometer.domain.archive.exception.ArchiveNotFoundException;
 import com.kilometer.domain.archive.like.Like;
 import com.kilometer.domain.archive.like.LikeRepository;
 import com.kilometer.domain.homeModules.ModuleParamDto;
@@ -35,7 +34,7 @@ public class RealTimeArchiveHandler implements ModuleHandler {
 
     @Override
     public Optional<RealTimeArchiveResponse> generator(final ModuleParamDto paramDto) {
-        List<RealTimeArchiveDto> realTimeArchiveDtos = archiveRepository.findTopFourArchivesWithImageUrl()
+        List<RealTimeArchiveDto> realTimeArchiveDtos = archiveRepository.findTopFourVisibleAtItemArchivesWithImageUrl()
                 .stream()
                 .map(archive -> archiveRepository.findRealTimeArchive(archive.getId()))
                 .map(this::combineVisitedPlaces)

--- a/kilometer-backend-domain/src/test/java/com/kilometer/archive/ArchiveRepositoryTest.java
+++ b/kilometer-backend-domain/src/test/java/com/kilometer/archive/ArchiveRepositoryTest.java
@@ -31,7 +31,6 @@ import com.kilometer.domain.user.User;
 import com.kilometer.domain.user.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -99,7 +98,7 @@ class ArchiveRepositoryTest {
                 saveArchiveImage(savedArchiveEntity);
             }
 
-            List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourArchivesWithImageUrl();
+            List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourVisibleAtItemArchivesWithImageUrl();
 
             assertThat(topFourArchivesWithImageUrl.size()).isEqualTo(4);
         }
@@ -112,7 +111,7 @@ class ArchiveRepositoryTest {
             saveArchiveImage(savedArchiveEntity);
             saveArchive(savedUser, ExposureType.ON, true);
 
-            List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourArchivesWithImageUrl();
+            List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourVisibleAtItemArchivesWithImageUrl();
 
             assertThat(topFourArchivesWithImageUrl.size()).isEqualTo(1);
         }
@@ -140,7 +139,7 @@ class ArchiveRepositoryTest {
         ArchiveEntity savedArchiveEntity = saveArchive(savedUser, ExposureType.ON, false);
         saveArchiveImage(savedArchiveEntity);
 
-        List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourArchivesWithImageUrl();
+        List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourVisibleAtItemArchivesWithImageUrl();
 
         assertThat(topFourArchivesWithImageUrl.size()).isEqualTo(0);
     }

--- a/kilometer-backend-domain/src/test/java/com/kilometer/archive/ArchiveRepositoryTest.java
+++ b/kilometer-backend-domain/src/test/java/com/kilometer/archive/ArchiveRepositoryTest.java
@@ -64,7 +64,7 @@ class ArchiveRepositoryTest {
     @Test
     void findReqlTimeArchive() {
         User savedUser = saveUser();
-        ArchiveEntity savedArchive = saveArchive(savedUser, ExposureType.ON);
+        ArchiveEntity savedArchive = saveArchive(savedUser, ExposureType.ON, true);
         saveUserVisitPlace(savedArchive);
         saveArchiveImage(savedArchive);
         saveArchiveLike(savedArchive, savedUser);
@@ -95,7 +95,7 @@ class ArchiveRepositoryTest {
         void findTopFourArchievsWithImageUrl() {
             User savedUser = saveUser();
             for (int i = 0; i < 6; i++) {
-                ArchiveEntity savedArchiveEntity = saveArchive(savedUser, ExposureType.ON);
+                ArchiveEntity savedArchiveEntity = saveArchive(savedUser, ExposureType.ON, true);
                 saveArchiveImage(savedArchiveEntity);
             }
 
@@ -108,9 +108,9 @@ class ArchiveRepositoryTest {
         @Test
         void ignoreArchivesThatDoesntHasImage() {
             User savedUser = saveUser();
-            ArchiveEntity savedArchiveEntity = saveArchive(savedUser, ExposureType.ON);
+            ArchiveEntity savedArchiveEntity = saveArchive(savedUser, ExposureType.ON, true);
             saveArchiveImage(savedArchiveEntity);
-            saveArchive(savedUser, ExposureType.ON);
+            saveArchive(savedUser, ExposureType.ON, true);
 
             List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourArchivesWithImageUrl();
 
@@ -121,7 +121,7 @@ class ArchiveRepositoryTest {
         @Test
         void ignoreArchivesThatUnexposed() {
             User savedUser = saveUser();
-            ArchiveEntity savedArchive = saveArchive(savedUser, ExposureType.OFF);
+            ArchiveEntity savedArchive = saveArchive(savedUser, ExposureType.OFF, true);
             saveUserVisitPlace(savedArchive);
             saveArchiveImage(savedArchive);
             saveArchiveLike(savedArchive, savedUser);
@@ -133,6 +133,18 @@ class ArchiveRepositoryTest {
         }
     }
 
+    @DisplayName("나만보기를 선택한 아카이브는 조회하지 않는다.")
+    @Test
+    void ignoreArchivesThatIsNotVisibleAtItem() {
+        User savedUser = saveUser();
+        ArchiveEntity savedArchiveEntity = saveArchive(savedUser, ExposureType.ON, false);
+        saveArchiveImage(savedArchiveEntity);
+
+        List<ArchiveEntity> topFourArchivesWithImageUrl = archiveRepository.findTopFourArchivesWithImageUrl();
+
+        assertThat(topFourArchivesWithImageUrl.size()).isEqualTo(0);
+    }
+
     private User saveUser() {
         User user = User.builder()
                 .name(USER_NAME)
@@ -142,7 +154,7 @@ class ArchiveRepositoryTest {
         return userRepository.save(user);
     }
 
-    private ArchiveEntity saveArchive(User user, ExposureType exposureType) {
+    private ArchiveEntity saveArchive(User user, ExposureType exposureType, boolean isVisibleAtItem) {
         ItemEntity item = ItemEntity.builder()
                 .exhibitionType(ExhibitionType.EXHIBITION)
                 .exposureType(exposureType)
@@ -167,7 +179,7 @@ class ArchiveRepositoryTest {
         ArchiveEntity archive = ArchiveEntity.builder()
                 .starRating(STAR_RATING)
                 .likeCount(LIKE_COUNT)
-                .isVisibleAtItem(true)
+                .isVisibleAtItem(isVisibleAtItem)
                 .comment(COMMENT)
                 .user(user)
                 .item(savedItem)


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.`
- [X] 🆗 로컬 스웨거에서 직접 실행해봤나요?
- [X] 💯 테스트는 잘 통과했나요? 
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
ArchiveRepositoryCustomImpl.findTopFourArchivesWithImageUrl() 로직 수정 및 메서드 이름 수정

## 스크린샷
as-is:
```
@Override
    public List<ArchiveEntity> findTopFourArchivesWithImageUrl() {
       return queryFactory.select(archiveEntity)
               .distinct()
               .from(archive)
               .leftJoin(archiveImageEntity)
               .on(archiveImageEntity.archiveEntity.eq(archive))
               .where(archiveImageEntity.isNotNull())
               .orderBy(archiveEntity.updatedAt.desc())
               .limit(MAX_ARCHIVES)
               .fetch();
    }
```

to-be:
```
@Override
    public List<ArchiveEntity> findTopFourVisibleAtItemArchivesWithImageUrl() {
       return queryFactory.select(archiveEntity)
               .distinct()
               .from(archive)
               .leftJoin(archiveImageEntity)
               .on(archiveImageEntity.archiveEntity.eq(archive))
               .where(archiveImageEntity.isNotNull(),
                       archiveEntity.isVisibleAtItem.isTrue())
               .orderBy(archiveEntity.updatedAt.desc())
               .limit(MAX_ARCHIVES)
               .fetch();
    }
```
## 주의사항

Closes #293 